### PR TITLE
Added click event to callback.

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -2,7 +2,7 @@ const directive = {}
 
 directive.onEvent = function (event) {
   if (event.target !== this.el && !this.el.contains(event.target)) {
-    directive.cb()
+    directive.cb(event)
   }
 }
 


### PR DESCRIPTION
There are times when it's not enough to know that you clicked outside an element, but you also want to know what got clicked outside. Rather than have two listeners, it would be nice to just get the click event from the click-outside event.