### PR TITLE
Allow multiple v-click-outside to be used with one listener

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -1,25 +1,37 @@
-const directive = {}
+const directive = {
+  els: []
+}
 
 directive.onEvent = function (event) {
-  if (event.target !== this.el && !this.el.contains(event.target)) {
-    directive.cb && directive.cb(event)
-  }
+  directive.els.forEach(function ([el, fn]) {
+    if (event.target !== el && !el.contains(event.target)) {
+      fn && fn(event)
+    }
+  })
 }
 
 directive.bind = function (el) {
-  directive.onEventBound = directive.onEvent.bind({ el })
-  document.addEventListener('click', directive.onEventBound)
+  directive.els.push([el, null])
+  if (directive.els.length === 1) {
+    document.addEventListener('click', directive.onEvent)
+  }
 }
 
 directive.update = function (el, binding) {
   if (typeof binding.value !== 'function') {
     throw new Error('Argument must be a function')
   }
-  directive.cb = binding.value
+  const entry = directive.els.find(([el1, _]) => el1 === el)
+  entry[1] = binding.value
 }
 
-directive.unbind = function () {
-  document.removeEventListener('click', directive.onEventBound)
+directive.unbind = function (el) {
+  const entry = directive.els.find(([el1, _]) => el1 === el)
+  const index = directive.els.indexOf(entry)
+  directive.els.splice(index, 1)
+  if (directive.els.length === 0) {
+    document.removeEventListener('click', directive.onEvent)
+  }
 }
 
 export default directive


### PR DESCRIPTION
The previous version was not working with multiple use of v-click-outside. This fix this by keeping a reference to all binded elements and registering only one listener.

If you unbind all elements, the listener is automatically removed.