### PR TITLE
Fix iPhone/iPad not triggering click event

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -1,3 +1,6 @@
+const userAgent = navigator.userAgent.toLowerCase()
+const event = userAgent.match(/(iphone|ipod|ipad)/) ? "touchstart" : "click"
+
 const directive = {
   instances: []
 }
@@ -13,7 +16,7 @@ directive.onEvent = function (event) {
 directive.bind = function (el) {
   directive.instances.push({ el, fn: null })
   if (directive.instances.length === 1) {
-    document.addEventListener('click', directive.onEvent)
+    document.addEventListener(event, directive.onEvent)
   }
 }
 
@@ -30,7 +33,7 @@ directive.unbind = function (el) {
   const instanceIndex = directive.instances.indexOf(instance)
   directive.instances.splice(instanceIndex, 1)
   if (directive.instances.length === 0) {
-    document.removeEventListener('click', directive.onEvent)
+    document.removeEventListener(event, directive.onEvent)
   }
 }
 


### PR DESCRIPTION
@ndelvalle first of all thanks for great lib!

There is one issue where iPhone/iPad is not triggering 'click' event that is fixed with this PR as for iPhone and iPad we are now listening for touchstart event not click event. 

You can find more info about issue [here](https://www.wpguru.com.au/responsive-web-design-tips/click-event-working-ipad-iphone-ipod-fixed/)

There is also lot of other post about that issue if you want to google it out