### PR TITLE
Revert "Remove use of findIndex to keep IE compatibility.".

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -29,8 +29,7 @@ directive.update = function (el, binding) {
 }
 
 directive.unbind = function (el) {
-  const instance = directive.instances.find(i => i.el === el)
-  const instanceIndex = directive.instances.indexOf(instance)
+  const instanceIndex = directive.instances.findIndex(i => i.el === el)
   directive.instances.splice(instanceIndex, 1)
   if (directive.instances.length === 0) {
     document.removeEventListener(event, directive.onEvent)


### PR DESCRIPTION
I realized that  `find` is also no available on IE, so no need to try keeping any compatibility.

We may add a note about that in the README.