### PR TITLE
Add a version hook to build package on publish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "rollup -c",
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "release": "np"
+    "release": "np",
+    "version": "yarn build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current released package don't include the latest updates. 

When publishing the package, the dist bundle is now builded.