### PR TITLE
Use a more cross-platform touch detection method

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -1,5 +1,5 @@
-const userAgent = navigator.userAgent.toLowerCase()
-const event = userAgent.match(/(iphone|ipod|ipad)/) ? 'touchstart' : 'click'
+const isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0));
+const event = isTouch ? 'touchstart' : 'click'
 
 const directive = {
   instances: []

--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -1,4 +1,4 @@
-const isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0));
+const isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0))
 const event = isTouch ? 'touchstart' : 'click'
 
 const directive = {


### PR DESCRIPTION
This PR makes the touch/click event detection more cross-platform, to support non-Apple touch devices.