### PR TITLE
Fix outside click when no update event were fired on component

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -13,8 +13,8 @@ directive.onEvent = function (event) {
   })
 }
 
-directive.bind = function (el) {
-  directive.instances.push({ el, fn: null })
+directive.bind = function (el, binding) {
+  directive.instances.push({ el, fn: binding.value })
   if (directive.instances.length === 1) {
     document.addEventListener(event, directive.onEvent)
   }


### PR DESCRIPTION
This plugin wasn't working for me completely. My simplest as possible div that only has one `v-click-outside` directive wasn't emitting the handler function when clicking outside.

```html
<template>
  <div v-click-outside="handleClickOutside">
      ...
  </div>
</template>

<script>
export default {
  methods: {
    handleClickOutside () {
      console.log('click') // Never triggered!
    }
  }
}
</script>
```

I debugged the plugin a bit, and it appears that it is because the handler is only getting registered on `directive.update` event, which never triggered in my case. So I also added it to `directive.bind` which will register the handler right away