### PR TITLE
Add a feature to adding only click event on mobile devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ import vClickOutside from 'v-click-outside'
 </template>
 ```
 
+On mobile devices, the plugin adds both of 'touchstart' and 'click' events to listners .  
+Use it with 'notouch' modifier, it adds only 'click' event.
+
+```js
+<template>
+  <div v-click-outside.notouch="onClickOutside"></div>
+</template>
+```
+
 ## License
 [MIT License](https://github.com/ndelvalle/v-click-outside/blob/master/LICENSE)
 

--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -15,6 +15,10 @@ directive.onEvent = function (event) {
 
 directive.bind = function (el, binding) {
   directive.instances.push({ el, fn: binding.value })
+  if (binding.modifiers && binding.modifiers.notouch) {
+    directive.events = ['click']
+  }
+
   if (directive.instances.length === 1) {
     directive.events.forEach(e => document.addEventListener(e, directive.onEvent))
   }

--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -6,7 +6,10 @@ const directive = {
 }
 
 directive.onEvent = function (event) {
-  directive.instances.forEach(({ el, fn }) => {
+  directive.instances.forEach(({ el, fn, mod }) => {
+    if (event.type === 'touchstart' && mod.notouch) {
+      return
+    }
     if (event.target !== el && !el.contains(event.target)) {
       fn && fn(event)
     }
@@ -14,11 +17,7 @@ directive.onEvent = function (event) {
 }
 
 directive.bind = function (el, binding) {
-  directive.instances.push({ el, fn: binding.value })
-  if (binding.modifiers && binding.modifiers.notouch) {
-    directive.events = ['click']
-  }
-
+  directive.instances.push({ el, fn: binding.value, mod: binding.modifiers })
   if (directive.instances.length === 1) {
     directive.events.forEach(e => document.addEventListener(e, directive.onEvent))
   }

--- a/test/v-click-outside.test.js
+++ b/test/v-click-outside.test.js
@@ -51,6 +51,13 @@ describe('v-click-outside -> directive', () => {
       expect(directive.instances[1].el).toBe(div2)
       expect(document.addEventListener.mock.calls.length).toBe(2)
     })
+
+    it('adds only one event listener (On mobile devices with notouch modifier)', () => {
+      document.addEventListener = jest.fn()
+      directive.events = ['click', 'touchstart']
+      directive.bind(div1, { modifiers: { notouch: true } })
+      expect(document.addEventListener.mock.calls.length).toBe(1)
+    })
   })
 
   describe('update', () => {

--- a/test/v-click-outside.test.js
+++ b/test/v-click-outside.test.js
@@ -51,13 +51,6 @@ describe('v-click-outside -> directive', () => {
       expect(directive.instances[1].el).toBe(div2)
       expect(document.addEventListener.mock.calls.length).toBe(2)
     })
-
-    it('adds only one event listener (On mobile devices with notouch modifier)', () => {
-      document.addEventListener = jest.fn()
-      directive.events = ['click', 'touchstart']
-      directive.bind(div1, { modifiers: { notouch: true } })
-      expect(document.addEventListener.mock.calls.length).toBe(1)
-    })
   })
 
   describe('update', () => {
@@ -124,6 +117,19 @@ describe('v-click-outside -> directive', () => {
       const event = { target: div1 }
       const cb = jest.fn()
       directive.bind(div1, {})
+      directive.update(div1, { value: cb })
+
+      directive.onEvent(event)
+      expect(cb).not.toHaveBeenCalled()
+    })
+
+    const messageNotouch = 'does not execute the callback if the event type is ' +
+                           'touchstart and the instance has notouch modifier'
+    it(messageNotouch, () => {
+      const event = { target: a, type: 'touchstart' }
+      const cb = jest.fn()
+      directive.events = ['click', 'touchstart']
+      directive.bind(div1, { modifiers: { notouch: true } })
       directive.update(div1, { value: cb })
 
       directive.onEvent(event)


### PR DESCRIPTION
On mobile devices, the plugin always adds 2 events 'touchstart' 'click' to listener.
But in some cases, it might as well adding only 'click' event also on mobile devices.

For example, there are a menu has `v-click-outside` to closeing menu and a menu's icon has `@click` to toggling opening and closing about the menu.
In this case, touch the menu icon when the menu opened, once the menu is closed and it will soon be opened. Because 'touchstart' event is fired before 'click' event.

```
<template>
  <span
    class="menu-icon"
    @click="toggleMenuOpeningClosing"
  ></span>
</template>

~~~~

<template>
  <div
    class="menu"
    v-click-outside="closeMenu"
  >
    <menu-contents/>
  </div>
</template>
```

To avoiding problems like this, I added a feature to enable to use 'notouch' modifier.
Using it, the plugin will add only click event on mobile devices.
Do you think about it ? 