### PR TITLE
Add middleware function to directive binding

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -17,7 +17,7 @@ directive.onEvent = function (event) {
 }
 
 directive.bind = function (el, binding) {
-  directive.instances.push({ el, fn: binding.value, mod: binding.modifiers, userFn: binding.middleware })
+  directive.instances.push({ el, fn: binding.value[Object.keys(binding.value)[0]], mod: binding.modifiers, userFn: binding.value.middleware })
   if (directive.instances.length === 1) {
     directive.events.forEach(e => document.addEventListener(e, directive.onEvent))
   }

--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -17,7 +17,9 @@ directive.onEvent = function (event) {
 }
 
 directive.bind = function (el, binding) {
-  directive.instances.push({ el, fn: binding.value[Object.keys(binding.value)[0]], mod: binding.modifiers, userFn: binding.value.middleware })
+  const handler = typeof binding.value === 'function' ? binding.value : binding.value.handler
+  const middleware = binding.value.middleware || (() => true)
+  directive.instances.push({ el, fn: handler, mod: binding.modifiers, userFn: middleware })
   if (directive.instances.length === 1) {
     directive.events.forEach(e => document.addEventListener(e, directive.onEvent))
   }

--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -6,18 +6,18 @@ const directive = {
 }
 
 directive.onEvent = function (event) {
-  directive.instances.forEach(({ el, fn, mod }) => {
+  directive.instances.forEach(({ el, fn, mod, userFn }) => {
     if (event.type === 'touchstart' && mod.notouch) {
       return
     }
-    if (event.target !== el && !el.contains(event.target)) {
+    if (event.target !== el && !el.contains(event.target) && userFn(el, event)) {
       fn && fn(event)
     }
   })
 }
 
 directive.bind = function (el, binding) {
-  directive.instances.push({ el, fn: binding.value, mod: binding.modifiers })
+  directive.instances.push({ el, fn: binding.value, mod: binding.modifiers, userFn: binding.middleware })
   if (directive.instances.length === 1) {
     directive.events.forEach(e => document.addEventListener(e, directive.onEvent))
   }


### PR DESCRIPTION
I added middleware as an optional binding to the directive signature. I haven't added tests yet, because I'm not sure of how the `bind` function works now. We need to either make an assumption that the first thing they pass will be the main click-outside callback, or we ask them to explicitly name it "onClick" so you can avoid having to use `Object.keys` to grab it. I think either way it would be a breaking change, right?  