### PR TITLE
Adds "active" functionality, closes instances memory leak.

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -3,6 +3,14 @@ const events = isTouch ? ['touchstart', 'click'] : ['click']
 
 const instances = []
 
+function funcIndexOf(array, func) {
+  for (let index = array.length - 1; index >= 0; index--) {
+    if (func(array[index])) return index
+  }
+
+  return -1
+}
+
 function processDirectiveArguments(bindingValue) {
   const isFunction = typeof bindingValue === 'function'
   if (!isFunction && typeof bindingValue !== 'object') {
@@ -13,6 +21,11 @@ function processDirectiveArguments(bindingValue) {
     handler: isFunction ? bindingValue : bindingValue.handler,
     middleware: bindingValue.middleware || ((isClickOutside) => isClickOutside),
     events: bindingValue.events || events,
+    active: isFunction
+      ? true
+      : bindingValue.active === undefined
+        ? true
+        : !!bindingValue.active
   }
 }
 
@@ -28,9 +41,8 @@ function onEvent({ el, event, handler, middleware }) {
   }
 }
 
-function bind(el, { value }) {
-  const { handler, middleware, events } = processDirectiveArguments(value)
 
+function createInstance(el, events, handler, middleware) {
   const instance = {
     el,
     eventHandlers: events.map((eventName) => ({
@@ -39,13 +51,43 @@ function bind(el, { value }) {
     })),
   }
 
-  instance.eventHandlers.forEach(({ event, handler }) => document.addEventListener(event, handler))
   instances.push(instance)
+
+  return instance
 }
 
+function destroyInstance(el) {
+  const instanceIndex = funcIndexOf(instances, (instance) => instance.el === el)
+  if (instanceIndex === -1) throw new Error(`unable to find a v-click-outside instance for el: ${el}`)
+
+  const instance = instances[instanceIndex]
+  instance.eventHandlers.forEach(({ event, handler }) =>
+    document.removeEventListener(event, handler),
+  )
+
+  instances.splice(instanceIndex, 1)
+}
+
+function bind(el, { value }) {
+  const { events, handler, middleware, active } = processDirectiveArguments(value)
+
+  if (!active) return
+
+  const instance = createInstance(el, events, handler, middleware)
+
+  instance.eventHandlers.forEach(({ event, handler }) => document.addEventListener(event, handler))
+}
+
+
 function update(el, { value }) {
-  const { handler, middleware, events } = processDirectiveArguments(value)
-  const instance = instances.find((instance) => instance.el === el)
+  const { events, handler, middleware, active } = processDirectiveArguments(value)
+
+  const instance = instances.find((instance) => instance.el === el) || createInstance(el, events, handler, middleware)
+
+  if (!active) {
+    destroyInstance(el)
+    return
+  }
 
   instance.eventHandlers.forEach(({ event, handler }) =>
     document.removeEventListener(event, handler),
@@ -59,17 +101,11 @@ function update(el, { value }) {
   instance.eventHandlers.forEach(({ event, handler }) => document.addEventListener(event, handler))
 }
 
-function unbind(el) {
-  const instance = instances.find((instance) => instance.el === el)
-  instance.eventHandlers.forEach(({ event, handler }) =>
-    document.removeEventListener(event, handler),
-  )
-}
 
 const directive = {
   bind,
   update,
-  unbind,
+  unbind: destroyInstance,
   instances,
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "v-click-outside",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3197,12 +3197,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3217,17 +3219,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3344,7 +3349,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3356,6 +3362,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3370,6 +3377,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3377,12 +3385,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3401,6 +3411,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3481,7 +3492,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3493,6 +3505,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3614,6 +3627,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/v-click-outside.test.js
+++ b/test/v-click-outside.test.js
@@ -5,6 +5,19 @@ import clickOutside from '../lib/index'
 const plugin = clickOutside
 const { directive } = clickOutside
 
+function makeConfig(argument) {
+  const noop = () => jest.fn()
+  return [
+    document.createElement('div'),
+    {
+      handler: noop,
+      events: ['dblclick'],
+      middleware: noop,
+      active: undefined,
+    }
+  ]
+}
+
 describe('v-click-outside -> plugin', () => {
   it('install the directive into the vue instance', () => {
     const vue = {
@@ -26,6 +39,7 @@ describe('v-click-outside -> directive', () => {
   describe('bind', () => {
     beforeEach(() => {
       document.addEventListener = jest.fn()
+      directive.instances.splice(0, directive.instances.length)
     })
 
     it('throws an error if the binding value is not a function or an object', () => {
@@ -34,13 +48,7 @@ describe('v-click-outside -> directive', () => {
     })
 
     it('adds an event listener to the element and stores an instance', () => {
-      const el = document.createElement('div')
-      const noop = () => jest.fn()
-      const config = {
-        handler: noop,
-        events: ['dblclick'],
-        middleware: noop,
-      }
+      const [el, config] = makeConfig()
 
       directive.bind(el, { value: config })
 
@@ -56,12 +64,95 @@ describe('v-click-outside -> directive', () => {
       expect(instance.el).toBe(el)
       expect(document.addEventListener).toHaveBeenCalledTimes(1)
     })
+
+    it("doesn't do anything when config.active is false", () => {
+      const [, config] = makeConfig()
+      config.active = false
+
+      directive.bind(null, { value: config })
+
+      expect(directive.instances.length).toEqual(0)
+    })
+  })
+
+  describe('unbind', () => {
+    it("can remove whatever bind adds", () => {
+      const [el1, config1] = makeConfig()
+      directive.bind(el1, { value: config1 })
+
+      expect(directive.instances.length).toEqual(1)
+
+      const [el2, config2] = makeConfig()
+      directive.bind(el2, { value: config2 })
+
+      expect(directive.instances.length).toEqual(2)
+
+      const [el3, config3] = makeConfig()
+      directive.bind(el3, { value: config3 })
+
+      expect(directive.instances.length).toEqual(3)
+
+      const els = directive.instances.map(instance => instance.el)
+      while (els.length) {
+        const el = els.pop()
+
+        directive.unbind(el)
+        expect(directive.instances.length).toEqual(els.length)
+      }
+    })
   })
 
   describe('update', () => {
     it('throws an error if the binding value is not a function or an object', () => {
       const update = () => directive.update(document.createElement('div'), {})
       expect(update).toThrowError(/v-click-outside: Binding value must be a function or an object/)
+    })
+
+    describe("transitions correctly", () => {
+      beforeEach(() => {
+        document.addEventListener = jest.fn()
+        document.removeEventListener = jest.fn()
+        directive.instances.splice(0, directive.instances.length)
+      })
+
+      it("from true to true", () => {
+        const [el, config] = makeConfig()
+        directive.bind(el, { value: config })
+        expect(directive.instances.length).toEqual(1)
+        expect(document.addEventListener).toHaveBeenCalledTimes(1)
+
+        directive.update(el, { value: config })
+        expect(directive.instances.length).toEqual(1)
+        expect(document.addEventListener).toHaveBeenCalledTimes(2)
+        expect(document.removeEventListener).toHaveBeenCalledTimes(1)
+      })
+      it("from true to false", () => {
+        const [el, config] = makeConfig()
+        directive.bind(el, { value: config })
+        expect(directive.instances.length).toEqual(1)
+        expect(document.addEventListener).toHaveBeenCalledTimes(1)
+
+        config.active = false
+        directive.update(el, { value: config })
+        expect(directive.instances.length).toEqual(0)
+        expect(document.addEventListener).toHaveBeenCalledTimes(1)
+        expect(document.removeEventListener).toHaveBeenCalledTimes(1)
+      })
+      it("from false to true", () => {
+        const [el, config] = makeConfig()
+        directive.update(el, { value: config })
+        expect(directive.instances.length).toEqual(1)
+        expect(document.addEventListener).toHaveBeenCalledTimes(1)
+        expect(document.removeEventListener).toHaveBeenCalledTimes(1)
+      })
+      it("from false to false", () => {
+        const [el, config] = makeConfig()
+        config.active = false
+        directive.update(el, { value: config })
+        expect(directive.instances.length).toEqual(0)
+        expect(document.addEventListener).toHaveBeenCalledTimes(0)
+        expect(document.removeEventListener).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/test/v-click-outside.test.js
+++ b/test/v-click-outside.test.js
@@ -71,6 +71,7 @@ describe('v-click-outside -> directive', () => {
 
       directive.bind(null, { value: config })
 
+      expect(document.addEventListener).toHaveBeenCalledTimes(0)
       expect(directive.instances.length).toEqual(0)
     })
   })


### PR DESCRIPTION
Hello!

I thought it would be nice to have an `active` switch on the config object, to basically prevent the handler from even being bound at all (for those situations where someone wants to avoid having too many handlers). It might be used like this:

```js
// pug: .thing(v-click-outside="computedConfig")
export default {
  computed: {
    computedConfig() {
      return {
        handler: this.handler,
        active: this.active,
      }
    }
  }
}
```


Also, I noticed while I was adding this that the `instances` list will grow without bound in the previous version of the code, because `unbind` didn't do anything to get rid of old instances. So I made a `destroyInstance` function that removes any existing event listeners and removes the item from the list.

Let me know how you feel about these changes!