### PR TITLE
Fix SSR issue when navigator is not defined

### DIFF
--- a/lib/v-click-outside.js
+++ b/lib/v-click-outside.js
@@ -1,5 +1,6 @@
-const isTouch =
-  typeof window !== 'undefined' && ('ontouchstart' in window || navigator.msMaxTouchPoints > 0)
+const hasWindow = typeof window !== 'undefined'
+const hasNavigator = typeof navigator !== 'undefined'
+const isTouch = hasWindow  && ('ontouchstart' in window || hasNavigator && navigator.msMaxTouchPoints > 0)
 const events = isTouch ? ['touchstart', 'click'] : ['click']
 
 const instances = []


### PR DESCRIPTION
This issue is actual when during SSR we use `global.window = { Vue }` for different workarounds. But `navigator` and `window.navigator` objects aren't existing.