### PR TITLE
After timeout, if el has already been unbound, do not attach event-listener

### DIFF
--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -49,10 +49,12 @@ function bind(el, { value }) {
   }))
 
   el[HANDLERS_PROPERTY].forEach(({ event, handler }) =>
-    setTimeout(
-      () => document.documentElement.addEventListener(event, handler, false),
-      0,
-    ),
+    setTimeout(() => {
+      if (!el[HANDLERS_PROPERTY]) {
+        return
+      }
+      document.documentElement.addEventListener(event, handler, false)
+    }, 0),
   )
 }
 


### PR DESCRIPTION
This check prevents possible memory leaks for detached elements. This case could happen with async data, when the unbind function runs before the timeout.