### PR TITLE
Remove redundant judgments

### DIFF
--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -29,9 +29,7 @@ function onEvent({ el, event, handler, middleware }) {
   //       In the meanwhile, we are using el.contains for those browsers, not
   //       the ideal solution, but using IE or EDGE is not ideal either.
   const path = event.path || (event.composedPath && event.composedPath())
-  const outsideCheck = path ? path.indexOf(el) < 0 : !el.contains(event.target)
-
-  const isClickOutside = event.target !== el && outsideCheck
+  const isClickOutside = path ? path.indexOf(el) < 0 : !el.contains(event.target)
 
   if (!isClickOutside) {
     return


### PR DESCRIPTION
I deleted the code `event.target! == el`. The reason is as follows:

- For `path.indexOf(el)`

If `el` is not in `event.path`，indicates that the click occurred outside `el`

- For `!el.contains(event.target)`

If `event.target` is not a descendant element of `el` or `el` itself，indicates that the click occurred outside `el`

Therefore, the additional judgment of `event.target! == el` is not needed.

(Forgive my poor english 😂)