### PR TITLE
Docs: programatic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,60 @@ import vClickOutside from 'v-click-outside'
 </template>
 ```
 
+Or use directive‘s hooks programatically
+
+```vue
+<script>
+  import vClickOutside from 'v-click-outside'
+  const { bind, unbind } = vClickOutside.directive
+
+  export default {
+    name: 'RenderlessExample',
+
+    mounted() {
+      const this._el = document.querySelector('data-ref', 'some-uid')
+      // Note: v-click-outside config or handler needs to be passed to the
+      //       "bind" function 2nd argument as object with a "value" key:
+      //       same as Vue’s directives "binding" format.
+      // https://vuejs.org/v2/guide/custom-directive.html#Directive-Hook-Arguments
+      bind(this._el, { value: this.onOutsideClick })
+    },
+    beforeDestroy() {
+      unbind(this._el)
+    },
+
+    methods: {
+      onClickOutside (event) {
+        console.log('Clicked outside. Event: ', event)
+      }
+    },
+
+    render() {
+      return this.$scopedSlots.default({
+        // Note: you can't pass vue's $refs (ref attribute) via slot-scope,
+        //       and have this.$refs property populated as it will be
+        //       interpreted as a regular html attribute. Workaround it 
+        //       with good old data-attr + querySelector combo.
+        props: { 'data-ref': 'some-uid' }
+      })
+    }
+  };
+</script>
+```
+
+```vue
+<!-- SomeComponent.vue -->
+<template>
+  <renderless-example v-slot:default="slotScope">
+    <div v-bind="slotScope.props">
+      Transparently bound v-click-outside directive via slotScope
+    </div>
+  </renderless-example>
+</template>
+```
+
+See [#220](https://github.com/ndelvalle/v-click-outside/issues/220) for details or [check-out this demo](https://codesandbox.io/s/v-click-outside-programatic-usage-o9drq)
+
 ## Example
 
 [![Edit v-click-outside](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/zx7mx8y1ol?module=%2Fsrc%2Fcomponents%2FHelloWorld.vue)

--- a/example/src/views/Home.vue
+++ b/example/src/views/Home.vue
@@ -9,11 +9,17 @@
       <div class="c13f10-box" v-click-outside="config">
         <p>Click Outside #c13f10 box</p>
       </div>
+      <div class="lime-box" ref="limeEl">
+        <p>Click Outside #lime box</p>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
+import vClickOutside from '../../../src'
+const { bind, unbind } = vClickOutside.directive
+
 export default {
   name: 'home',
 
@@ -28,6 +34,14 @@ export default {
     }
   },
 
+  mounted() {
+    bind(this.$refs.limeEl, { value: this.lime })
+  },
+
+  beforeDestroy() {
+    unbind(this.$refs.limeEl)
+  },
+
   methods: {
     ffefd5(ev) {
       console.log('Clicked outside ffefd5!', ev)
@@ -39,6 +53,9 @@ export default {
     middleware(ev) {
       console.log('Middleware!', ev)
       return true
+    },
+    lime(ev) {
+      console.log('Clicked outside lime!', ev)
     },
   },
 }
@@ -53,6 +70,11 @@ export default {
 
 .c13f10-box {
   background-color: #c13f10;
+  height: 50px;
+}
+
+.lime-box {
+  background-color: lime;
   height: 50px;
 }
 </style>

--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -29,7 +29,9 @@ function onEvent({ el, event, handler, middleware }) {
   //       In the meanwhile, we are using el.contains for those browsers, not
   //       the ideal solution, but using IE or EDGE is not ideal either.
   const path = event.path || (event.composedPath && event.composedPath())
-  const isClickOutside = path ? path.indexOf(el) < 0 : !el.contains(event.target)
+  const isClickOutside = path
+    ? path.indexOf(el) < 0
+    : !el.contains(event.target)
 
   if (!isClickOutside) {
     return


### PR DESCRIPTION
Following the discussion, closes https://github.com/ndelvalle/v-click-outside/issues/220. 

### Implementation details
- adds docs on programatic usage, using `scopedSlots` as usecase.
- Includes demo at `example/` and `codesandbox` live example.
- Side-effect: ran `prettier` on `v-click-outside.js`, to ensure I could start dev server for the `example/` code


### Notes
Changes to the code proposed on #1 were basically sugaring/shortcut imports  an as such was dismissed in favour o destructing the methods straight from `directive` imported object.