### PR TITLE
fix: iframe click detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Vue.use(vClickOutside)
         events: ['dblclick', 'click'],
         // Note: The default value is true, but in case you want to activate / deactivate
         //       this directive dynamically use this attribute.
-        isActive: true
+        isActive: true,
+        // Note: The default value is true. See detecting "Detecting Iframe Clicks" section
+        //       to understand why this behaviour is behind a flag.
+        detectIFrame: true
       }
     },
     methods: {
@@ -153,6 +156,19 @@ The `notouch` modifier is no longer supported, same functionality can be achieve
 ## Migrate from version 2
 
 The HTML `el` is not sent in the handler function argument any more. Review [this issue](https://github.com/ndelvalle/v-click-outside/issues/137) for more details.
+
+## Detecting Iframe Clicks
+
+To our knowledge, there isn't an idiomatic way to detect a click on a `<iframe>` (`HTMLIFrameElement`).
+Clicks on iframes moves `focus` to its contents’ `window` but don't `bubble` up to main `window`, therefore not triggering our `document.documentElement` listeners. On the other hand, the abovementioned `focus` event does trigger a `window.blur` event on main `window` that we use in conjunction with `document.activeElement` to detect if it came from an `<iframe>`, and execute the provided `handler`.
+
+**As with any workaround, this also has its caveats:**
+
+- Click outside will be triggered once on iframe. Subsequent clicks on iframe will not execute the handler **until focus has been moved back to main window** — as in by clicking anywhere outside the iframe. This is the "expected" behaviour since, as mentioned before, by clicking the iframe focus will move to iframe contents — a different window, so subsequent clicks are inside its frame. There might be way to workaround this such as calling window.focus() at the end of the provided handler but that will break normal tab/focus flow;
+- Moving focus to `iframe` via `keyboard` navigation also triggers `window.blur` consequently the handler - no workaround found ATM;
+
+Because of these reasons, the detection mechansim is behind the `detectIframe` flag that you can optionally set to `false` if you find it conflicting with your use-case.
+Any improvements or suggestions to this are welcomed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,40 +95,40 @@ Or use directive‘s hooks programatically
 
 ```vue
 <script>
-  import vClickOutside from 'v-click-outside'
-  const { bind, unbind } = vClickOutside.directive
+import vClickOutside from 'v-click-outside'
+const { bind, unbind } = vClickOutside.directive
 
-  export default {
-    name: 'RenderlessExample',
+export default {
+  name: 'RenderlessExample',
 
-    mounted() {
-      const this._el = document.querySelector('data-ref', 'some-uid')
-      // Note: v-click-outside config or handler needs to be passed to the
-      //       "bind" function 2nd argument as object with a "value" key:
-      //       same as Vue’s directives "binding" format.
-      // https://vuejs.org/v2/guide/custom-directive.html#Directive-Hook-Arguments
-      bind(this._el, { value: this.onOutsideClick })
-    },
-    beforeDestroy() {
-      unbind(this._el)
-    },
+  mounted() {
+    const this._el = document.querySelector('data-ref', 'some-uid')
+    // Note: v-click-outside config or handler needs to be passed to the
+    //       "bind" function 2nd argument as object with a "value" key:
+    //       same as Vue’s directives "binding" format.
+    // https://vuejs.org/v2/guide/custom-directive.html#Directive-Hook-Arguments
+    bind(this._el, { value: this.onOutsideClick })
+  },
+  beforeDestroy() {
+    unbind(this._el)
+  },
 
-    methods: {
-      onClickOutside (event) {
-        console.log('Clicked outside. Event: ', event)
-      }
-    },
-
-    render() {
-      return this.$scopedSlots.default({
-        // Note: you can't pass vue's $refs (ref attribute) via slot-scope,
-        //       and have this.$refs property populated as it will be
-        //       interpreted as a regular html attribute. Workaround it 
-        //       with good old data-attr + querySelector combo.
-        props: { 'data-ref': 'some-uid' }
-      })
+  methods: {
+    onClickOutside (event) {
+      console.log('Clicked outside. Event: ', event)
     }
-  };
+  },
+
+  render() {
+    return this.$scopedSlots.default({
+      // Note: you can't pass vue's $refs (ref attribute) via slot-scope,
+      //       and have this.$refs property populated as it will be
+      //       interpreted as a regular html attribute. Workaround it
+      //       with good old data-attr + querySelector combo.
+      props: { 'data-ref': 'some-uid' }
+    })
+  }
+};
 </script>
 ```
 

--- a/example/src/views/Home.vue
+++ b/example/src/views/Home.vue
@@ -12,6 +12,7 @@
       <div class="lime-box" ref="limeEl">
         <p>Click Outside #lime box</p>
       </div>
+      <iframe class="iframe" src="/about" width="100%" />
     </div>
   </div>
 </template>
@@ -77,5 +78,9 @@ export default {
   background-color: lime;
   height: 50px;
 }
-</style>
 
+.iframe {
+  border: 1px solid lightgrey;
+  margin-top: 1em;
+}
+</style>


### PR DESCRIPTION
Attempt to close #80 with iframe click detection workaround.

Clicks on iframe don't bubble, so they are undetected by our `document.documentElement` listeners. Workarounds in the SO threads and dev internet fall into 3 categories:
1. add pseudo-elements cover ups on iframes, blocking click on iframe content but still bubbling document click;
1. wrap iframes on an extra <div> and capture the click on it;
1. `window.onblur` + `document.activeElement` combo;

The last one seemed the less intrusive:
- it doesn't block clicks on iframe content itself;
- it doesn't add extra DIVs which could cause layout issues;
- it keeps performance impact to a minimum;

### How it works
The gist is that a click on an iframe will move `focus` to it. Since iframe has its own `window` our main app window will `blur`: on that event we can then check if `document.activeElement` is an IFRAME and execute the handler.

### Implementation details
~~adds a custom `vco:faux-iframe-click` eventName id to the provided  eventsNames array, this will be used to perform conditional logic:~~
~~- bind `blur` event to window instead of document.documentElement;~~
~~- use `onFauxIframeClick` instead of default `onEvent` as handler wrapper;~~
- Adds `detectIframe` config flag that defaults to `true` — see https://github.com/ndelvalle/v-click-outside/pull/222#issuecomment-682088501
- if `true`, the following event object will be merged together with `el[HANDLERS_PROPERTY]` array.
   ```js
    {
      event: 'blur',
      srcTarget: window,
      handler: (event) => onFauxIframeClick({ event, handler, middleware }),
    }
   ```
- The regular loop through `el[HANDLERS_PROPERTY]` for event binding will occur, but now also binds our special blur event to the `window`
- `onFauxIframeClick` doesn't require the event path of regular `onEvent`, i simply checks if `document.activeElement` is an iframe and wraps `handler` execution into a `setTimeout` to workaround an issue with Firefox, that only sets `activeElement` correctly after blur, on the next tick (event loop).
- Documents the following `#caveats` section under `README.md`

### Caveats
- Click outside will be triggered once on iframe. Subsequent clicks **on iframe** will not execute the handler **until focus** has been moved back to main window — by clicking anywhere outside the `iframe`. This is the "expected" behaviour as by clicking the iframe, focus will move to iframe contents — a different window, so subsequent clicks are inside it. There might be way to workaround this such as calling `window.focus()` at the end of the provided handler but that will break normal tab/focus flow, therefore decided to not be included in the source code.
- Moving focus to iframe via tab navigation also triggers `window.blur` consequently the `faux-click-outside` handler - no workaround found ATM.