### PR TITLE
IE11 fix: Added check for activeElement

### DIFF
--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -36,7 +36,7 @@ function onFauxIframeClick({ el, event, handler, middleware }) {
   // https://stackoverflow.com/q/2381336#comment61192398_23231136
   setTimeout(() => {
     const { activeElement } = document
-    if (activeElement.tagName === 'IFRAME' && !el.contains(activeElement)) {
+    if (activeElement && activeElement.tagName === 'IFRAME' && !el.contains(activeElement)) {
       execHandler({ event, handler, middleware })
     }
   }, 0)

--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -36,7 +36,11 @@ function onFauxIframeClick({ el, event, handler, middleware }) {
   // https://stackoverflow.com/q/2381336#comment61192398_23231136
   setTimeout(() => {
     const { activeElement } = document
-    if (activeElement && activeElement.tagName === 'IFRAME' && !el.contains(activeElement)) {
+    if (
+      activeElement &&
+      activeElement.tagName === 'IFRAME' &&
+      !el.contains(activeElement)
+    ) {
       execHandler({ event, handler, middleware })
     }
   }, 0)


### PR DESCRIPTION
Under certain conditions IE11 throws an error, indicating that it can't access tagName of activeElement.
For me it happens, when I'm closing a modal. Then activeElement is null.

In this PR I've just added a null check to prevent undefined access.