### PR TITLE
Proposal to add support of capture option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ Vue.use(vClickOutside)
         isActive: true,
         // Note: The default value is true. See "Detecting Iframe Clicks" section
         //       to understand why this behaviour is behind a flag.
-        detectIFrame: true
+        detectIFrame: true,
+        // Note: The default value is false. Sets the capture option for EventTarget addEventListener method.
+        //       Could be useful if some event's handler calls stopPropagation method preventing event bubbling.
+        capture: false
       }
     },
     methods: {

--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -81,6 +81,7 @@ function bind(el, { value }) {
     event: eventName,
     srcTarget: document.documentElement,
     handler: (event) => onEvent({ el, event, handler, middleware }),
+    capture,
   }))
 
   if (detectIframe) {

--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -21,6 +21,7 @@ function processDirectiveArguments(bindingValue) {
     events: bindingValue.events || EVENTS,
     isActive: !(bindingValue.isActive === false),
     detectIframe: !(bindingValue.detectIframe === false),
+    capture: !!bindingValue.capture,
   }
 }
 
@@ -70,6 +71,7 @@ function bind(el, { value }) {
     middleware,
     isActive,
     detectIframe,
+    capture,
   } = processDirectiveArguments(value)
   if (!isActive) {
     return
@@ -86,6 +88,7 @@ function bind(el, { value }) {
       event: 'blur',
       srcTarget: window,
       handler: (event) => onFauxIframeClick({ el, event, handler, middleware }),
+      capture,
     }
 
     el[HANDLERS_PROPERTY] = [...el[HANDLERS_PROPERTY], detectIframeEvent]
@@ -98,15 +101,15 @@ function bind(el, { value }) {
       if (!el[HANDLERS_PROPERTY]) {
         return
       }
-      srcTarget.addEventListener(event, handler, false)
+      srcTarget.addEventListener(event, handler, capture)
     }, 0),
   )
 }
 
 function unbind(el) {
   const handlers = el[HANDLERS_PROPERTY] || []
-  handlers.forEach(({ event, srcTarget, handler }) =>
-    srcTarget.removeEventListener(event, handler, false),
+  handlers.forEach(({ event, srcTarget, handler, capture }) =>
+    srcTarget.removeEventListener(event, handler, capture),
   )
   delete el[HANDLERS_PROPERTY]
 }

--- a/test/v-click-outside.test.js
+++ b/test/v-click-outside.test.js
@@ -116,6 +116,23 @@ describe('v-click-outside -> directive', () => {
 
       expect(window.addEventListener).toHaveBeenCalledTimes(1)
     })
+
+    it('checks that event listener is set correctly with capture option passed', () => {
+      const directive = createDirective()
+      const [el, binding] = createHookArguments()
+      binding.value.capture = true
+
+      directive.bind(el, binding)
+      jest.runOnlyPendingTimers()
+
+      el[HANDLERS_PROPERTY].forEach(({ event, srcTarget, handler }) =>
+        expect(srcTarget.addEventListener).toHaveBeenCalledWith(
+          event,
+          handler,
+          true,
+        ),
+      )
+    })
   })
 
   describe('unbind', () => {
@@ -167,6 +184,26 @@ describe('v-click-outside -> directive', () => {
 
       directive.unbind(el)
       expect(window.removeEventListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('removes event listeners with capture option passed', () => {
+      const directive = createDirective()
+
+      const [el, binding] = createHookArguments()
+      binding.value.capture = true
+      directive.bind(el, binding)
+      jest.runOnlyPendingTimers()
+
+      const elSettings = el[HANDLERS_PROPERTY]
+      directive.unbind(el)
+
+      elSettings.forEach(({ event, srcTarget, handler }) =>
+        expect(srcTarget.removeEventListener).toHaveBeenCalledWith(
+          event,
+          handler,
+          true,
+        ),
+      )
     })
   })
 


### PR DESCRIPTION
Proposal to add support of capture option to support click detection on elements using stopPropagation method.

If some element uses stopPropagation() method for click event, this directive doesn't trigger. Using explicit capture for these elements solves the issue.