### PR TITLE
fix: Don't use deprecated Event.path if composedPath() exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-click-outside",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Vue directive to react on clicks outside an element",
   "main": "dist/v-click-outside.umd.js",
   "umd:main": "dist/v-click-outside.umd.js",

--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -52,7 +52,7 @@ function onEvent({ el, event, handler, middleware }) {
   //       https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
   //       In the meanwhile, we are using el.contains for those browsers, not
   //       the ideal solution, but using IE or EDGE is not ideal either.
-  const path = event.path || (event.composedPath && event.composedPath())
+  const path = (event.composedPath && event.composedPath()) || event.path
   const isClickOutside = path
     ? path.indexOf(el) < 0
     : !el.contains(event.target)


### PR DESCRIPTION
Hello!
Thank you, I always use the awesome library.

Event.path is deprecated on Chrome since about May 3rd.
https://chromestatus.com/feature/5726124632965120

But Internet Explorer has only Event.path.
I tried that it works with both browsers.

fix #533

