### PR TITLE
fix: IE11 to use click event

### DIFF
--- a/src/v-click-outside.js
+++ b/src/v-click-outside.js
@@ -1,10 +1,6 @@
 const HANDLERS_PROPERTY = '__v-click-outside'
 const HAS_WINDOWS = typeof window !== 'undefined'
-const HAS_NAVIGATOR = typeof navigator !== 'undefined'
-const IS_TOUCH =
-  HAS_WINDOWS &&
-  ('ontouchstart' in window ||
-    (HAS_NAVIGATOR && navigator.msMaxTouchPoints > 0))
+const IS_TOUCH = HAS_WINDOWS && 'ontouchstart' in window
 const EVENTS = IS_TOUCH ? ['touchstart'] : ['click']
 
 function processDirectiveArguments(bindingValue) {


### PR DESCRIPTION
Hi.

I can not use it well on Internet Explorer 11.
It adds `touchstart` events on IE11.

`navigator.msMaxTouchPoints` is grater than 0 on IE11.
`navigator.MaxTouchPoints` is the same.
![ 2022-05-17 11 16 13](https://user-images.githubusercontent.com/7115203/168719430-1043666d-0f7f-4d93-aed6-3d8e203bb690.png)

I think it is enough to judge only whether there is `ontouchstart`.
https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ontouchstart